### PR TITLE
chore: add :automergeMinor and :automergeDigest to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabled": false,
   "extends": [
-    "local>qlik-oss/renovate-config"
+    "local>qlik-oss/renovate-config",
+    ":automergeMinor",
+    ":automergeDigest"
   ]
 }


### PR DESCRIPTION
Add `:automergeMinor` and `:automergeDigest` explicitly. The shared preset (qlik-oss/renovate-config) no longer provides these — adding them here preserves existing automerge behaviour and adds digest update automerge.